### PR TITLE
Correctly handle jsonlint._lintcheck()'s return

### DIFF
--- a/demjson.py
+++ b/demjson.py
@@ -6255,7 +6255,9 @@ the options --allow, --warn, or --forbid ; for example:
 
         for fn in args:
             try:
-                if not self._lintcheck( fn, output_filename=output_filename,
+                if self.SUCCESS_FAIL == self._lintcheck(
+                                        fn,
+                                        output_filename=output_filename,
                                         verbose=verbose,
                                         reformat=reformat,
                                         show_stats=show_stats,


### PR DESCRIPTION
This fixes a bug whereby jsonlint always returns 0 unless a
KeyboardInterrupt is caught
