### PR TITLE
Error types need to converted into booleans

### DIFF
--- a/demjson.py
+++ b/demjson.py
@@ -6029,7 +6029,12 @@ MORE INFORMATION:
             verbose_fp.write('%sok, with warnings\n' % pfx)
         elif verbose_fp:
             verbose_fp.write("%shas errors\n" % pfx)
-
+        
+        if success == self.SUCCESS_OK:
+            success = True
+        else:
+            success = False
+        
         return success
 
 


### PR DESCRIPTION
I noticed that jsonlint return values don’t work properly. Code outside this method treats these values as booleans.

Steps to reproduce:

```
tmp $ cat test.json
{
    "foo" : [ 1,2,3]
}
tmp $ jsonlint test.json
test.json: ok
tmp $ echo $?
0
tmp $ cat test.json
{
    "foo" : [ 1,2,3
}
tmp $ jsonlint test.json
test.json:3:0: Error: Expected a ']' but saw '}'
   |  At line 3, column 0, offset 22
   |  Array started at line 2, column 12, offset 14
test.json: has errors
tmp $ echo $?
0
```

`$?` should be 1, and after applying the attached patch it is.
