### PR TITLE
Enable setuptools command 'test'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: python
+
+sudo: false
+
+python:
+ - 3.5
+ - 3.4
+ - 3.3
+ - 3.2
+ - 2.7
+ - 2.6
+ - pypy3
+ - pypy
+
+script:
+ - python setup.py install
+ - if [ $TRAVIS_PYTHON_VERSION == "3.2" ]; then 2to3 -w test/test_demjson.py; fi
+ - python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -1,51 +1,8 @@
 # Python package setup script        -*- coding: utf-8 -*-
+from setuptools import setup
 
 name = 'demjson'
 version = '2.2.4'
-
-import sys
-try:
-    py_major = sys.version_info.major
-except AttributeError:
-    py_major = sys.version_info[0]
-
-distmech = None
-if py_major >= 3:
-    # Python 3, use setuptools first
-    try:
-        from setuptools import setup
-        distmech = 'setuptools'
-    except ImportError:
-        from distutils.core import setup
-        distmech = 'distutils'
-else:
-    # Python 2, use distutils first
-    try:
-        from distutils.core import setup
-        distmech = 'distutils'
-    except ImportError:
-        from setuptools import setup
-        distmech = 'setuptools'
-
-if False:
-    sys.stdout.write("Using Python:    %s\n" % sys.version.split(None,1)[0])
-    sys.stdout.write("Using installer: %s\n" % distmech )
-
-py3extra = {}
-
-if py_major >= 3:
-    # Make sure 2to3 gets run
-    if distmech == 'setuptools':
-        py3extra['use_2to3'] = True
-        #py3extra['convert_2to3_doctests'] = ['src/your/module/README.txt']
-        #py3extra['use_2to3_fixers'] = ['your.fixers']
-    elif distmech == 'distutils':
-        import distutils, distutils.command, distutils.command.build_py, distutils.command.build_scripts
-        cmdclass = {
-            'build_py':      distutils.command.build_py.build_py_2to3,
-            'build_scripts': distutils.command.build_scripts.build_scripts_2to3
-            }
-        py3extra['cmdclass'] = cmdclass
 
 setup( name=name,
        version=version,
@@ -82,6 +39,7 @@ for parsing JavaScript data which may not strictly be valid JSON data.
                     "Topic :: Software Development :: Libraries :: Python Modules",
                     "Topic :: Internet :: WWW/HTTP :: Dynamic Content"
                     ],
-       **py3extra
+       use_2to3=True,
+       test_suite="test.test_demjson",
        )
 

--- a/test/test_demjson.py
+++ b/test/test_demjson.py
@@ -43,9 +43,16 @@ try:
 except ImportError:
     decimal = None
 
+if is_python3:
+    basestring = str
+    long = int
+    unichr = chr
+
 # ====================
 
 if hasattr(unittest, 'skipUnless'):
+    def skipUnlessPython2(method):
+        return unittest.skipUnless(method, not is_python3)
     def skipUnlessPython3(method):
         return unittest.skipUnless(method, is_python3)
     def skipUnlessPython27(method):
@@ -56,19 +63,21 @@ else:
     # Python <= 2.6 does not have skip* decorators, so
     # just make a dummy decorator that always passes the
     # test method.
+    def skipUnlessPython2(method):
+        return method
     def skipUnlessPython3(method):
         def always_pass(self):
-            print "\nSKIPPING TEST %s: Requires Python 3" % method.__name__
+            print("\nSKIPPING TEST %s: Requires Python 3" % method.__name__)
             return True
         return always_pass
     def skipUnlessPython27(method):
         def always_pass(self):
-            print "\nSKIPPING TEST %s: Requires Python 2.7 or greater" % method.__name__
+            print("\nSKIPPING TEST %s: Requires Python 2.7 or greater" % method.__name__)
             return True
         return always_pass
     def skipUnlessWidePython(method):
         def always_pass(self):
-            print "\nSKIPPING TEST %s: Requires Python with wide Unicode support (maxunicode > U+FFFF)" % method.__name__
+            print("\nSKIPPING TEST %s: Requires Python with wide Unicode support (maxunicode > U+FFFF)" % method.__name__)
             return True
         return always_pass
 
@@ -176,7 +185,7 @@ class rot_one(codecs.CodecInfo):
                 chars.append( unichr(b-1) )
             elif b == ord('A'):
                 chars.append( u'Z' )
-            elif b <= 0x7fL:
+            elif b <= 127:
                 chars.append( unichr(b) )
             else:
                 raise UnicodeDecodeError('rot-1',byte_list,i,i,"Can not decode byte value 0x%02x"%b)
@@ -411,11 +420,11 @@ class DemjsonTest(unittest.TestCase):
         try:
             m = r.match( value )
         except TypeError:
-            raise self.failureException, \
-                  "can't compare non-string to regex: %r" % value
+            raise self.failureException(
+                  "can't compare non-string to regex: %r" % value)
         if m is None:
-            raise self.failureException, \
-                  (msg or '%r !~ /%s/' %(value,pattern))
+            raise self.failureException(
+                  msg or '%r !~ /%s/' %(value,pattern))
 
     def testEncodeNumber(self):
         self.assertEqual(demjson.encode(0), '0')
@@ -953,11 +962,14 @@ class DemjsonTest(unittest.TestCase):
                         if self.n < 10:
                             return 2**self.n
                         raise StopIteration
+                i.__next__ = i.next
                 return i()
+
         mylist = LikeList()
         self.assertEqual(demjson.encode(mylist), \
                          '[2,4,8,16,32,64,128,256,512]' )
 
+    @skipUnlessPython2
     def testEncodeStringLike(self):
         import UserString
         class LikeString(UserString.UserString):
@@ -1249,12 +1261,12 @@ class DemjsonTest(unittest.TestCase):
         self.assertRaises( demjson.JSONEncodeError, demjson.encode, Anon2("Hello"), encode_default=encode_anon )
 
     def testEncodeDate(self):
-        d = datetime.date(2014,01,04)
+        d = datetime.date(2014,1,4)
         self.assertEqual(demjson.encode( d ), '"2014-01-04"' )
         self.assertEqual(demjson.encode( d, date_format='%m/%d/%Y' ), '"01/04/2014"' )
 
     def testEncodeDatetime(self):
-        d = datetime.datetime(2014,01,04,13,22,15)
+        d = datetime.datetime(2014,1,4,13,22,15)
         self.assertEqual(demjson.encode( d ), '"2014-01-04T13:22:15"' )
         self.assertEqual(demjson.encode( d, datetime_format='%m/%d/%Y %H hr %M min' ), '"01/04/2014 13 hr 22 min"' )
 
@@ -1493,9 +1505,9 @@ class DemjsonTest(unittest.TestCase):
 
 def run_all_tests():
     unicode_width = 'narrow' if sys.maxunicode<=0xFFFF else 'wide'
-    print 'Running with demjson version %s, Python version %s with %s-Unicode' % (demjson.__version__, sys.version.split(' ',1)[0],unicode_width)
+    print('Running with demjson version %s, Python version %s with %s-Unicode' % (demjson.__version__, sys.version.split(' ',1)[0],unicode_width))
     if int( demjson.__version__.split('.',1)[0] ) < 2:
-        print 'WARNING: TESTING AGAINST AN OLD VERSION!'
+        print('WARNING: TESTING AGAINST AN OLD VERSION!')
     unittest.main()
     
 if __name__ == '__main__':


### PR DESCRIPTION
Use setuptools on both Python 2 and 3.
Convert unit tests to use Python 2 and 3 compatible syntax,
but use 2to3 on Python 3.2 which did not have u'..' syntax.

Run travis tests using setup.py test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dmeranda/demjson/19)
<!-- Reviewable:end -->
