### PR TITLE
Fix bug in Enum encoding

### DIFF
--- a/demjson.py
+++ b/demjson.py
@@ -5191,7 +5191,7 @@ class JSON(object):
             self.encode_composite( obj, state )
 
 
-    def encode_enum(self, val, state):
+    def encode_enum(self, obj, state):
         """Encode a Python Enum value into JSON."""
         eas = self.options.encode_enum_as
         if eas == 'qname':


### PR DESCRIPTION
The code refers to obj, but the parameter is named var.
Renamed to obj to be consistent with calling code variable names.