### PR TITLE
Fix a syntax typo

### DIFF
--- a/demjson.py
+++ b/demjson.py
@@ -4852,7 +4852,7 @@ class JSON(object):
                 obj = self.decode_string(state)
             elif c.isdigit() or c in '.+-':
                 obj = self.decode_number(state)
-            elif c.isalpha() or c in'_$':
+            elif c.isalpha() or c in '_$':
                 obj = self.decode_identifier(state, identifier_as_string=identifier_as_string)
             else:
                 state.push_error('Can not decode value starting with character %r' % c)


### PR DESCRIPTION
This worked for now, but is SyntaxError in Python 3.9.0a6:

```
  File "/usr/lib/python3.9/site-packages/demjson.py", line 4853
    elif c.isalpha() or c in'_$':
                           ^
SyntaxError: invalid string prefix
```

(The Python change might actually be [reverted](https://github.com/python/cpython/pull/19888) before 3.9 final, but this can be fixed anyway.)